### PR TITLE
Fixed importing from `@types/` (wrong package name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Options:
                            Used types will be imported by "import { First,
                            Second } from 'library-name';".
                            By default all libraries will be imported (except
-                           inlined)                                      [array]
+                           inlined and libraries from @types)            [array]
   --external-types         Array of the package names from @types to import
                            typings from it via triple-slash reference directive.
                            By default all packages are allowed and will be used

--- a/src/bin/dts-bundle-generator.ts
+++ b/src/bin/dts-bundle-generator.ts
@@ -71,7 +71,7 @@ const args = yargs
 		type: 'array',
 		description: 'Array of the package names from node_modules to import typings from it.\n' +
 			'Used types will be imported by "import { First, Second } from \'library-name\';".\n' +
-			'By default all libraries will be imported (except inlined)',
+			'By default all libraries will be imported (except inlined and libraries from @types)',
 		coerce: toStringsArray,
 	})
 	.option('external-types', {

--- a/src/module-info.ts
+++ b/src/module-info.ts
@@ -89,7 +89,7 @@ function getModuleInfoImpl(currentFilePath: string, originalFileName: string, cr
 	}
 
 	if (shouldLibraryBeImported(npmLibraryName, typesLibraryName, criteria.importedLibraries)) {
-		return { type: ModuleType.ShouldBeImported, fileName: originalFileName, libraryName: npmLibraryName, isExternal: true };
+		return { type: ModuleType.ShouldBeImported, fileName: originalFileName, libraryName: typesLibraryName || npmLibraryName, isExternal: true };
 	}
 
 	if (typesLibraryName !== null && isLibraryAllowed(typesLibraryName, criteria.allowedTypesLibraries)) {

--- a/tests/test-cases/import-from-types/config.ts
+++ b/tests/test-cases/import-from-types/config.ts
@@ -2,7 +2,7 @@ import { TestCaseConfig } from '../test-case-config';
 
 const config: TestCaseConfig = {
 	generatorOptions: {
-		importedLibraries: ['fs'],
+		importedLibraries: ['fs', 'fake-types-lib'],
 	},
 };
 

--- a/tests/test-cases/import-from-types/input.ts
+++ b/tests/test-cases/import-from-types/input.ts
@@ -1,5 +1,7 @@
+import { InterfaceFromTypesPackage } from 'fake-types-lib';
 import { Stats } from 'fs';
 
 export interface InterfaceName {
 	prop: Stats;
+	field: InterfaceFromTypesPackage;
 }

--- a/tests/test-cases/import-from-types/output.d.ts
+++ b/tests/test-cases/import-from-types/output.d.ts
@@ -1,5 +1,7 @@
+import { InterfaceFromTypesPackage } from 'fake-types-lib';
 import { Stats } from 'fs';
 
 export interface InterfaceName {
 	prop: Stats;
+	field: InterfaceFromTypesPackage;
 }

--- a/tests/test-cases/node_modules/@types/fake-types-lib/index.d.ts
+++ b/tests/test-cases/node_modules/@types/fake-types-lib/index.d.ts
@@ -1,0 +1,5 @@
+export interface InterfaceFromTypesPackage {
+	field: string;
+	field2: number;
+	field3: string | number;
+}


### PR DESCRIPTION
- [x] Add one more exception for `--external-imports`'s cli option default behavior (see `except inlined` in help) - `and libraries from @types/`

Fixes #37 
