### PR TITLE
Added `inline-declare-externals` CLI option to enable inlining declare module statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Options:
   --inline-declare-global       Enables inlining of `declare global` statements contained in files
                                 which should be inlined (all local files and packages from
                                 `--external-inlines`)                     [boolean] [default: false]
+  --inline-declare-externals    Enables inlining of `declare module` statements of the global
+                                modules (e.g. `declare module 'external-module' {}`, but NOT
+                                `declare module './internal-module' {}`) contained in files which
+                                should be inlined (all local files and packages from inlined
+                                libraries)                                [boolean] [default: false]
   --disable-symlinks-following  (EXPERIMENTAL) Disables resolving of symlinks to the original path.
                                 See https://github.com/timocov/dts-bundle-generator/issues/39 for
                                 more information                          [boolean] [default: false]

--- a/src/bin/dts-bundle-generator.ts
+++ b/src/bin/dts-bundle-generator.ts
@@ -37,6 +37,7 @@ interface ParsedArgs extends yargs.Arguments {
 	'no-check': boolean;
 	'fail-on-class': boolean;
 	'inline-declare-global': boolean;
+	'inline-declare-externals': boolean;
 	'disable-symlinks-following': boolean;
 
 	'out-file': string | undefined;
@@ -115,6 +116,11 @@ function parseArgs(): ParsedArgs {
 			default: false,
 			description: 'Enables inlining of `declare global` statements contained in files which should be inlined (all local files and packages from `--external-inlines`)',
 		})
+		.option('inline-declare-externals', {
+			type: 'boolean',
+			default: false,
+			description: 'Enables inlining of `declare module` statements of the global modules (e.g. `declare module \'external-module\' {}`, but NOT `declare module \'./internal-module\' {}`) contained in files which should be inlined (all local files and packages from inlined libraries)',
+		})
 		.option('disable-symlinks-following', {
 			type: 'boolean',
 			default: false,
@@ -176,6 +182,7 @@ function main(): void {
 						inlinedLibraries: args['external-inlines'],
 					},
 					output: {
+						inlineDeclareExternals: args['inline-declare-externals'],
 						inlineDeclareGlobals: args['inline-declare-global'],
 						umdModuleName: args['umd-module-name'],
 						sortNodes: args.sort,

--- a/src/config-file/load-config-file.ts
+++ b/src/config-file/load-config-file.ts
@@ -72,6 +72,7 @@ const configScheme: SchemeDescriptor<BundlerConfig> = {
 			},
 			output: {
 				inlineDeclareGlobals: schemaPrimitiveValues.boolean,
+				inlineDeclareExternals: schemaPrimitiveValues.boolean,
 				sortNodes: schemaPrimitiveValues.boolean,
 				umdModuleName: schemaPrimitiveValues.string,
 			},

--- a/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/.gitignore
+++ b/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/.gitignore
@@ -1,0 +1,1 @@
+!/ambient-module-declaration.d.ts

--- a/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/ambient-module-declaration.d.ts
+++ b/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/ambient-module-declaration.d.ts
@@ -1,0 +1,2 @@
+declare module 'ambient-module' {
+}

--- a/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/config.ts
+++ b/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/config.ts
@@ -1,9 +1,5 @@
 import { TestCaseConfig } from '../../test-cases/test-case-config';
 
-const config: TestCaseConfig = {
-	output: {
-		inlineDeclareExternals: true,
-	},
-};
+const config: TestCaseConfig = {};
 
 export = config;

--- a/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/input.ts
+++ b/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/input.ts
@@ -1,0 +1,15 @@
+// this test case comes from Dexie.js
+
+/// <reference path="./ambient-module-declaration.d.ts" />
+
+import { Interface } from './interface';
+
+export interface InterfaceInternal extends Interface {}
+
+declare module ModuleName {
+	export interface Interface extends InterfaceInternal {}
+}
+
+declare var ModuleName: { prototype: Interface };
+
+export { ModuleName };

--- a/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/interface.ts
+++ b/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/interface.ts
@@ -1,0 +1,3 @@
+export interface Interface {
+	field: Interface;
+}

--- a/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/output.d.ts
+++ b/tests/test-cases/dont-inline-declare-extenal-modules-in-internal-files/output.d.ts
@@ -1,0 +1,8 @@
+export interface Interface {
+	field: Interface;
+}
+export interface InterfaceInternal extends Interface {
+}
+export declare var ModuleName: {
+	prototype: Interface;
+};


### PR DESCRIPTION
Previously it was enabled by default without ability to disable it.
Now it disabled by default (breaking change) and we can override it via CLI or config.

Fixes #75