### PR TITLE
Ignore TS18003 error in while parsing config

### DIFF
--- a/src/get-compiler-options.ts
+++ b/src/get-compiler-options.ts
@@ -6,6 +6,10 @@ import { fixPath } from './helpers/fix-path';
 import { checkDiagnosticsErrors } from './helpers/check-diagnostics-errors';
 import { verboseLog } from './logger';
 
+const enum Constants {
+	NoInputsWereFoundDiagnosticCode = 18003,
+}
+
 const parseConfigHost: ts.ParseConfigHost = {
 	useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
 	readDirectory: ts.sys.readDirectory,
@@ -29,7 +33,12 @@ export function getCompilerOptions(inputFileNames: ReadonlyArray<string>, prefer
 		getAbsolutePath(configFileName)
 	);
 
-	checkDiagnosticsErrors(compilerOptionsParseResult.errors, 'Error while processing tsconfig compiler options');
+	// we don't want to raise an error if no inputs found in a config file
+	// because this error is mostly for CLI, but we'll pass an inputs in createProgram
+	const diagnostics = compilerOptionsParseResult.errors
+		.filter((d: ts.Diagnostic) => d.code !== Constants.NoInputsWereFoundDiagnosticCode);
+
+	checkDiagnosticsErrors(diagnostics, 'Error while processing tsconfig compiler options');
 
 	return compilerOptionsParseResult.options;
 }

--- a/tests/e2e/test-cases/include-exclude-in-tsconfig/config.ts
+++ b/tests/e2e/test-cases/include-exclude-in-tsconfig/config.ts
@@ -1,0 +1,5 @@
+import { TestCaseConfig } from '../test-case-config';
+
+const config: TestCaseConfig = {};
+
+export = config;

--- a/tests/e2e/test-cases/include-exclude-in-tsconfig/input.ts
+++ b/tests/e2e/test-cases/include-exclude-in-tsconfig/input.ts
@@ -1,0 +1,1 @@
+export type FooBar = number;

--- a/tests/e2e/test-cases/include-exclude-in-tsconfig/output.d.ts
+++ b/tests/e2e/test-cases/include-exclude-in-tsconfig/output.d.ts
@@ -1,0 +1,3 @@
+export declare type FooBar = number;
+
+export {};

--- a/tests/e2e/test-cases/include-exclude-in-tsconfig/tsconfig.json
+++ b/tests/e2e/test-cases/include-exclude-in-tsconfig/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"preserveConstEnums": true
+	},
+	"include": [
+		"inputs.ts"
+	],
+	"exclude": [
+		"**/*.js"
+	]
+}


### PR DESCRIPTION
It's "No inputs were found in config file" error