### PR TITLE
Add "declare" to variable declarations

### DIFF
--- a/src/generate-output.ts
+++ b/src/generate-output.ts
@@ -120,8 +120,12 @@ function getStatementText(statement: ts.Statement, helpers: OutputHelpers): Stat
 
 	// for some reason TypeScript allows to do not write `declare` keyword for ClassDeclaration or VariableDeclaration
 	// if it already has `export` keyword - so we need to add it
-	if ((ts.isClassDeclaration(statement) && /^class\b/.test(nodeText)) ||
-	     ts.isVariableStatement(statement) && /^(const|let|var)\b/.test(nodeText)){
+	function isNeedToAddDeclare(statement: ts.Statement, nodeText: string): boolean {
+		return (ts.isClassDeclaration(statement) && /^class\b/.test(nodeText)) ||
+				(ts.isVariableStatement(statement) && /^(const|let|var)\b/.test(nodeText));
+	}
+
+	if (isNeedToAddDeclare(statement, nodeText)) {
 		nodeText = `declare ${nodeText}`;
 	}
 

--- a/src/generate-output.ts
+++ b/src/generate-output.ts
@@ -118,9 +118,10 @@ function getStatementText(statement: ts.Statement, helpers: OutputHelpers): Stat
 		nodeText = nodeText.replace(/\bdefault\s/, ts.isClassDeclaration(statement) ? 'declare ' : '');
 	}
 
-	// for some reason TypeScript allows to do not write `declare` keyword for ClassDeclaration
+	// for some reason TypeScript allows to do not write `declare` keyword for ClassDeclaration or VariableDeclaration
 	// if it already has `export` keyword - so we need to add it
-	if (ts.isClassDeclaration(statement) && /^class\b/.test(nodeText)) {
+	if ((ts.isClassDeclaration(statement) && /^class\b/.test(nodeText)) ||
+	     ts.isVariableStatement(statement) && /^(const|let|var)\b/.test(nodeText)){
 		nodeText = `declare ${nodeText}`;
 	}
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -7,7 +7,7 @@ New folder's name will be used as name of test case.
 
 Each test case must have at least 3 files:
 
-1. `index.ts` - the entry point of test case (this file will used to generate typings).
+1. `input.ts` or `input.d.ts` - the entry point of test case (this file will used to generate typings).
 1. `output.d.ts` - file with expected output - it will be used to compare with just generated (actual) typings.
 1. `config.ts` - file with test case config (e.g. generator options). It must export test case config (see [test-case-config.ts](./test-cases/test-case-config.ts) for type) via `export =`.
 

--- a/tests/e2e/all-test-cases.ts
+++ b/tests/e2e/all-test-cases.ts
@@ -31,7 +31,11 @@ function getTestCases(): TestCase[] {
 		.map((directoryName: string) => {
 			const testCaseDir = path.resolve(testCasesDir, directoryName);
 			const outputFileName = path.resolve(testCaseDir, 'output.d.ts');
-			const inputFileName = path.relative(process.cwd(), path.resolve(testCaseDir, 'input.ts'));
+
+			const _ts = path.relative(process.cwd(), path.resolve(testCaseDir, 'input.ts'));
+			const _dts = path.relative(process.cwd(), path.resolve(testCaseDir, 'input.d.ts'));
+
+			const inputFileName = fs.existsSync(_ts) ? _ts : _dts;
 
 			assert(fs.existsSync(inputFileName), `Input file doesn't exist for ${directoryName}`);
 			assert(fs.existsSync(outputFileName), `Output file doesn't exist for ${directoryName}`);

--- a/tests/e2e/test-cases/top-level-declarations/.gitignore
+++ b/tests/e2e/test-cases/top-level-declarations/.gitignore
@@ -1,0 +1,2 @@
+!input.d.ts
+!library.d.ts

--- a/tests/e2e/test-cases/top-level-declarations/config.ts
+++ b/tests/e2e/test-cases/top-level-declarations/config.ts
@@ -1,0 +1,5 @@
+import { TestCaseConfig } from '../test-case-config';
+
+const config: TestCaseConfig = {};
+
+export = config;

--- a/tests/e2e/test-cases/top-level-declarations/input.d.ts
+++ b/tests/e2e/test-cases/top-level-declarations/input.d.ts
@@ -1,0 +1,8 @@
+import { variable, SampleClass, ISample, SampleNS } from "./library";
+
+export namespace Sample {
+    export { variable }
+    export { SampleClass }
+    export { ISample }
+    export { SampleNS }
+}

--- a/tests/e2e/test-cases/top-level-declarations/library.d.ts
+++ b/tests/e2e/test-cases/top-level-declarations/library.d.ts
@@ -1,0 +1,7 @@
+export const variable: string;
+
+export class SampleClass {}
+
+export interface ISample {}
+
+export namespace SampleNS {}

--- a/tests/e2e/test-cases/top-level-declarations/output.d.ts
+++ b/tests/e2e/test-cases/top-level-declarations/output.d.ts
@@ -1,0 +1,12 @@
+declare const variable: string;
+declare class SampleClass {}
+export interface ISample {}
+export namespace SampleNS {}
+export namespace Sample {
+	export { variable }
+	export { SampleClass }
+	export { ISample }
+	export { SampleNS }
+}
+
+export {};


### PR DESCRIPTION
When I import d.ts file and reexport it in a namespace, unlike class,
"declare" is not added to variable declarations.

As a result, ts1046 error occurred, so fix it.