### PR TITLE
Fixed handling `export =` with namespaces in all external modules (not only imported ones)

### DIFF
--- a/src/bundle-generator.ts
+++ b/src/bundle-generator.ts
@@ -378,8 +378,8 @@ function updateResult(params: UpdateParams, result: CollectingResult): void {
 			continue;
 		}
 
-		if (ts.isExportAssignment(statement) && statement.isExportEquals && params.currentModule.type === ModuleType.ShouldBeImported) {
-			updateResultForImportedEqExportAssignment(statement, params, result);
+		if (ts.isExportAssignment(statement) && statement.isExportEquals && params.currentModule.isExternal) {
+			updateResultForExternalEqExportAssignment(statement, params, result);
 			continue;
 		}
 
@@ -453,7 +453,7 @@ function updateResultForRootSourceFile(params: UpdateParams, result: CollectingR
 	}
 }
 
-function updateResultForImportedEqExportAssignment(exportAssignment: ts.ExportAssignment, params: UpdateParams, result: CollectingResult): void {
+function updateResultForExternalEqExportAssignment(exportAssignment: ts.ExportAssignment, params: UpdateParams, result: CollectingResult): void {
 	const moduleDeclarations = params.getDeclarationsForExportedAssignment(exportAssignment)
 		.filter(isNamespaceStatement)
 		.filter((s: ts.ModuleDeclaration) => s.getSourceFile() === exportAssignment.getSourceFile());

--- a/tests/e2e/test-cases/import-from-namespace-in-cjs/config.ts
+++ b/tests/e2e/test-cases/import-from-namespace-in-cjs/config.ts
@@ -1,0 +1,9 @@
+import { TestCaseConfig } from '../test-case-config';
+
+const config: TestCaseConfig = {
+	libraries: {
+		inlinedLibraries: ['ora'],
+	},
+};
+
+export = config;

--- a/tests/e2e/test-cases/import-from-namespace-in-cjs/input.ts
+++ b/tests/e2e/test-cases/import-from-namespace-in-cjs/input.ts
@@ -1,0 +1,4 @@
+import { Options } from 'ora';
+
+export declare const ExportedValue: Options;
+export type ExportedType = Options;

--- a/tests/e2e/test-cases/import-from-namespace-in-cjs/output.d.ts
+++ b/tests/e2e/test-cases/import-from-namespace-in-cjs/output.d.ts
@@ -1,0 +1,5 @@
+export interface Options { }
+export declare const ExportedValue: Options;
+export declare type ExportedType = Options;
+
+export {};

--- a/tests/e2e/test-cases/node_modules/ora/index.d.ts
+++ b/tests/e2e/test-cases/node_modules/ora/index.d.ts
@@ -1,0 +1,9 @@
+declare namespace ora {
+	interface Options { }
+}
+
+declare const ora: {
+	(options: ora.Options): any;
+};
+
+export = ora;


### PR DESCRIPTION
Fixed #124