### PR TITLE
Fix example command line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Examples:
 ```
 
 ```bash
-./node_modules/.bin/dts-bundle-generator --external-inlines=@mycompany/internal-project --external-imports=@angular/core,rxjs path/to/your/entry-file.ts
+./node_modules/.bin/dts-bundle-generator --external-inlines=@mycompany/internal-project --external-imports=@angular/core rxjs path/to/your/entry-file.ts
 ```
 
 ```bash


### PR DESCRIPTION
Hey there,

very useful project, thank's for maintaining it! I was struggling for a bit to get `--external-imports <package>` right because I used commas instead of spaces to separate multiple packages like in the README. So I suppose the example command should be updated.