### PR TITLE
fix: not handling `export default value` when `exportReferencedTypes` is `false`

### DIFF
--- a/src/bundle-generator.ts
+++ b/src/bundle-generator.ts
@@ -304,10 +304,7 @@ export function generateDtsBundle(entries: readonly EntryPointConfig[], options:
 					// an export keyword (like interface, type, etc) otherwise, if there are
 					// only re-exports with renaming (like export { foo as bar }) we don't need
 					// to put export keyword for this statement because we'll re-export it in the way
-					const hasStatementedDefaultKeyword = ts.isExportAssignment(statement)
-						? !statement.isExportEquals
-						: hasNodeModifier(statement, ts.SyntaxKind.DefaultKeyword);
-
+					const hasStatementedDefaultKeyword = hasNodeModifier(statement, ts.SyntaxKind.DefaultKeyword);
 					let result = statementExports.length === 0 || statementExports.find((exp: SourceFileExport) => {
 						// "directly" means "without renaming" or "without additional node/statement"
 						// for instance, `class A {} export default A;` - here `statement` is `class A {}`
@@ -471,12 +468,27 @@ function updateResultForRootSourceFile(params: UpdateParams, result: CollectingR
 
 	// add skipped by `updateResult` exports
 	for (const statement of params.statements) {
-		// "export default" or "export ="
-		const isExportAssignment = ts.isExportAssignment(statement);
-		const isReExportFromImportable = isReExportFromImportableModule(statement);
-
-		if (isExportAssignment || isReExportFromImportable) {
+		// "export =" or "export {} from 'importable-package'"
+		if (ts.isExportAssignment(statement) && statement.isExportEquals || isReExportFromImportableModule(statement)) {
 			result.statements.push(statement);
+			continue;
+		}
+
+		// "export default"
+		if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
+			// `export default 123`, `export default "str"`
+			if (!ts.isIdentifier(statement.expression)) {
+				result.statements.push(statement);
+				continue;
+			}
+
+			const exportedNameNode = params.resolveIdentifier(statement.expression);
+			if (exportedNameNode === undefined) {
+				continue;
+			}
+
+			const originalName = exportedNameNode.getText();
+			result.renamedExports.push(`${originalName} as default`);
 			continue;
 		}
 

--- a/src/bundle-generator.ts
+++ b/src/bundle-generator.ts
@@ -304,7 +304,10 @@ export function generateDtsBundle(entries: readonly EntryPointConfig[], options:
 					// an export keyword (like interface, type, etc) otherwise, if there are
 					// only re-exports with renaming (like export { foo as bar }) we don't need
 					// to put export keyword for this statement because we'll re-export it in the way
-					const hasStatementedDefaultKeyword = hasNodeModifier(statement, ts.SyntaxKind.DefaultKeyword);
+					const hasStatementedDefaultKeyword = ts.isExportAssignment(statement)
+						? !statement.isExportEquals
+						: hasNodeModifier(statement, ts.SyntaxKind.DefaultKeyword);
+
 					let result = statementExports.length === 0 || statementExports.find((exp: SourceFileExport) => {
 						// "directly" means "without renaming" or "without additional node/statement"
 						// for instance, `class A {} export default A;` - here `statement` is `class A {}`

--- a/src/helpers/typescript.ts
+++ b/src/helpers/typescript.ts
@@ -27,9 +27,6 @@ export function hasNodeModifier(node: ts.Node, modifier: ts.SyntaxKind): boolean
 export function getNodeName(node: ts.Node): NodeName | undefined {
 	const nodeName = (node as unknown as ts.NamedDeclaration).name;
 	if (nodeName === undefined) {
-		if (ts.isExportAssignment(node) && !node.isExportEquals) {
-			return node.expression as ts.Identifier;
-		}
 		const defaultModifier = node.modifiers?.find((mod: ts.Modifier) => mod.kind === ts.SyntaxKind.DefaultKeyword);
 		if (defaultModifier !== undefined) {
 			return defaultModifier;

--- a/src/helpers/typescript.ts
+++ b/src/helpers/typescript.ts
@@ -27,6 +27,9 @@ export function hasNodeModifier(node: ts.Node, modifier: ts.SyntaxKind): boolean
 export function getNodeName(node: ts.Node): NodeName | undefined {
 	const nodeName = (node as unknown as ts.NamedDeclaration).name;
 	if (nodeName === undefined) {
+		if (ts.isExportAssignment(node) && !node.isExportEquals) {
+			return node.expression as ts.Identifier;
+		}
 		const defaultModifier = node.modifiers?.find((mod: ts.Modifier) => mod.kind === ts.SyntaxKind.DefaultKeyword);
 		if (defaultModifier !== undefined) {
 			return defaultModifier;

--- a/tests/e2e/test-cases/export-default-exist-class/output.d.ts
+++ b/tests/e2e/test-cases/export-default-exist-class/output.d.ts
@@ -1,5 +1,8 @@
 export declare class MyAwesomeClass {
 }
-export default MyAwesomeClass;
+
+export {
+	MyAwesomeClass as default,
+};
 
 export {};

--- a/tests/e2e/test-cases/export-default-just-declared-class-from-entry/output.d.ts
+++ b/tests/e2e/test-cases/export-default-just-declared-class-from-entry/output.d.ts
@@ -1,5 +1,8 @@
 declare class MyClass {
 }
-export default MyClass;
+
+export {
+	MyClass as default,
+};
 
 export {};

--- a/tests/e2e/test-cases/export-default-no-export-referenced-types/config.ts
+++ b/tests/e2e/test-cases/export-default-no-export-referenced-types/config.ts
@@ -1,7 +1,6 @@
 import { TestCaseConfig } from '../test-case-config';
 
 const config: TestCaseConfig = {
-	failOnClass: true,
 	output: {
 		exportReferencedTypes: false,
 	},

--- a/tests/e2e/test-cases/export-default-no-export-referenced-types/config.ts
+++ b/tests/e2e/test-cases/export-default-no-export-referenced-types/config.ts
@@ -1,0 +1,10 @@
+import { TestCaseConfig } from '../test-case-config';
+
+const config: TestCaseConfig = {
+	failOnClass: true,
+	output: {
+		exportReferencedTypes: false,
+	},
+};
+
+export = config;

--- a/tests/e2e/test-cases/export-default-no-export-referenced-types/input.ts
+++ b/tests/e2e/test-cases/export-default-no-export-referenced-types/input.ts
@@ -1,0 +1,3 @@
+const foo = "bar";
+
+export default foo;

--- a/tests/e2e/test-cases/export-default-no-export-referenced-types/output.d.ts
+++ b/tests/e2e/test-cases/export-default-no-export-referenced-types/output.d.ts
@@ -1,4 +1,7 @@
 declare const foo = "bar";
-export default foo;
+
+export {
+	foo as default,
+};
 
 export {};

--- a/tests/e2e/test-cases/export-default-no-export-referenced-types/output.d.ts
+++ b/tests/e2e/test-cases/export-default-no-export-referenced-types/output.d.ts
@@ -1,0 +1,4 @@
+declare const foo = "bar";
+export default foo;
+
+export {};

--- a/tests/e2e/test-cases/export-variables-list/output.d.ts
+++ b/tests/e2e/test-cases/export-variables-list/output.d.ts
@@ -1,5 +1,8 @@
 declare const defaultExportedString = "str", justExportedNumber = 123;
 export declare const exportedString = "str";
-export default defaultExportedString;
+
+export {
+	defaultExportedString as default,
+};
 
 export {};

--- a/tests/e2e/test-cases/extend-other-module-complex/output.d.ts
+++ b/tests/e2e/test-cases/extend-other-module-complex/output.d.ts
@@ -10,6 +10,9 @@ declare function getRandom(): number;
 interface SomeInterface {
 	field: typeof getRandom;
 }
-export default SomeInterface;
+
+export {
+	SomeInterface as default,
+};
 
 export {};


### PR DESCRIPTION
this fixes
```ts
const foo = "bar"
export default foo
```
being compiled to
```ts
// Generated by dts-bundle-generator v6.10.0

declare const foo = "bar";
foo;

export {};
```

which causes `Error: Compiled with errors` from `error TS1036: Statements are not allowed in ambient contexts.`

it now compiles to
```ts
// Generated by dts-bundle-generator v6.10.0

declare const foo = "bar";

export {
	foo as default,
};

export {};
```