### PR TITLE
Improve support of non-relative imports in projects with a baseUrl

### DIFF
--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/config.ts
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/config.ts
@@ -1,0 +1,5 @@
+import { TestCaseConfig } from '../../test-cases/test-case-config';
+
+const config: TestCaseConfig = {};
+
+export = config;

--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/input.ts
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/input.ts
@@ -1,0 +1,5 @@
+import { returnMyType } from "field/type";
+
+export function test() {
+    return returnMyType()
+}

--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/output.d.ts
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/output.d.ts
@@ -1,0 +1,6 @@
+export interface MyType {
+	field: string;
+}
+export declare function test(): MyType;
+
+export {};

--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/src/field/type.ts
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/src/field/type.ts
@@ -1,0 +1,9 @@
+export interface MyType {
+	field: string;
+}
+
+export function returnMyType(): MyType {
+    return {
+        field: "test"
+    }
+}

--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/tsconfig.json
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": "./src"
+	}
+}


### PR DESCRIPTION
Thanks for all your work on this great project @timocov.

I noticed a small issue when using non-relative imports in TypeScript projects with a `baseUrl` configured. It appears that `resolveModuleFileName` treats all modules that isn't prefixed with a `.` [as an external node_module](https://github.com/timocov/dts-bundle-generator/blob/c88676269c37e23f2a070a24dd6f5d5f569e08aa/src/bundle-generator.ts#L586), which causes `needStripImportFromImportTypeNode` to not strip these generated `import()` statements.

For example, prior to this change, the result of the `import-from-non-relative-path-inferred-type` test would be:

```ts
export interface MyType {
	field: string;
}
export declare function test(): import("field/type").MyType;

export {};
```

The `import()` here is unnecessary since `MyType` is already defined in the declaration file, and should be stripped.

This PR currently resolves the issue described above by, when a `baseUrl` is defined, checking whether a module exists relative to that baseUrl, before falling back to `node_modules/${moduleName}/` if the module does not exist at that path.