### PR TITLE
 Improve support of non-relative imports in projects with a baseUrl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         node-version: 12
     - run: npm install
-    - run: npm install typescript@3.0.1
+    - run: npm install typescript@4.0.2
     - run: npm run tsc
 
   ts-current:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 14
     - run: npm install
     - run: npm run lint
 
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 14
     - run: npm install
     - run: npm install typescript@4.0.2
     - run: npm run tsc
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 14
     - run: npm install
     - run: npm run tsc
     - run: npm run test
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 14
     - run: npm install
     - run: npm install typescript@next
     - run: npm run tsc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         node-version: 14
     - run: npm install
-    - run: npm install typescript@4.0.2
+    - run: npm install typescript@4.5.2
     - run: npm run tsc
 
   ts-current:

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -7,7 +7,7 @@ const config = {
 	recursive: true,
 	diff: true,
 	timeout: 10000,
-	slow: 2500,
+	slow: 5000,
 };
 
 if (process.env.TESTS_REPORT_FILE) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/timocov/dts-bundle-generator",
   "dependencies": {
-    "typescript": ">=3.0.1",
+    "typescript": ">=4.0.2",
     "yargs": "^17.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/timocov/dts-bundle-generator",
   "dependencies": {
-    "typescript": ">=4.0.2",
+    "typescript": ">=4.5.2",
     "yargs": "^17.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,23 +18,23 @@
   "homepage": "https://github.com/timocov/dts-bundle-generator",
   "dependencies": {
     "typescript": ">=4.0.2",
-    "yargs": "^17.2.1"
+    "yargs": "^17.6.0"
   },
   "devDependencies": {
-    "@types/mocha": "~9.1.1",
-    "@types/node": "~12.12.47",
-    "@types/yargs": "~17.0.5",
-    "@typescript-eslint/eslint-plugin": "~5.28.0",
-    "@typescript-eslint/parser": "~5.28.0",
-    "eslint": "~8.18.0",
+    "@types/mocha": "~10.0.0",
+    "@types/node": "~14.18.26",
+    "@types/yargs": "~17.0.13",
+    "@typescript-eslint/eslint-plugin": "~5.38.1",
+    "@typescript-eslint/parser": "~5.38.1",
+    "eslint": "~8.24.0",
     "eslint-plugin-import": "~2.26.0",
     "eslint-plugin-prefer-arrow": "~1.2.1",
-    "eslint-plugin-unicorn": "~42.0.0",
+    "eslint-plugin-unicorn": "~44.0.0",
     "mocha": "~10.0.0",
     "npm-run-all": "~4.1.5",
     "rimraf": "~3.0.2",
-    "ts-compiler": "npm:typescript@4.8.2",
-    "ts-node": "~10.8.1"
+    "ts-compiler": "npm:typescript@4.8.4",
+    "ts-node": "~10.9.1"
   },
   "license": "MIT",
   "readme": "README.md",
@@ -43,7 +43,7 @@
     "url": "git+https://github.com/timocov/dts-bundle-generator.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "clean": "rimraf dist/ dts-out/",

--- a/src/bundle-generator.ts
+++ b/src/bundle-generator.ts
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
 import * as path from 'path';
-import * as fs from 'fs';
 
 import { compileDts } from './compile-dts';
 import { TypesUsageEvaluator } from './types-usage-evaluator';
@@ -139,9 +138,7 @@ export function generateDtsBundle(entries: readonly EntryPointConfig[], options:
 	const { program, rootFilesRemapping } = compileDts(entries.map((entry: EntryPointConfig) => entry.filePath), options.preferredConfigPath, options.followSymlinks);
 	const typeChecker = program.getTypeChecker();
 
-	const compilerOptions = program.getCompilerOptions();
-	const typeRoots = ts.getEffectiveTypeRoots(compilerOptions, {});
-	const baseUrl = compilerOptions.baseUrl;
+	const typeRoots = ts.getEffectiveTypeRoots(program.getCompilerOptions(), {});
 
 	const sourceFiles = program.getSourceFiles().filter((file: ts.SourceFile) => {
 		return !program.isSourceFileDefaultLibrary(file);
@@ -232,8 +229,17 @@ export function generateDtsBundle(entries: readonly EntryPointConfig[], options:
 
 				return leftSymbols.some((leftSymbol: ts.Symbol) => rightSymbols.includes(leftSymbol));
 			},
-			resolveReferencedModule: (node: ts.ExportDeclaration | ts.ModuleDeclaration) => {
-				const moduleName = ts.isExportDeclaration(node) ? node.moduleSpecifier : node.name;
+			resolveReferencedModule: (node: ts.ExportDeclaration | ts.ModuleDeclaration | ts.ImportTypeNode) => {
+				let moduleName: ts.Expression | ts.LiteralTypeNode | undefined;
+
+				if (ts.isExportDeclaration(node)) {
+					moduleName = node.moduleSpecifier;
+				} else if (ts.isModuleDeclaration(node)) {
+					moduleName = node.name;
+				} else if (ts.isLiteralTypeNode(node.argument) && ts.isStringLiteral(node.argument.literal)) {
+					moduleName = node.argument.literal;
+				}
+
 				if (moduleName === undefined) {
 					return null;
 				}
@@ -359,9 +365,12 @@ export function generateDtsBundle(entries: readonly EntryPointConfig[], options:
 						return false;
 					}
 
-					// we don't need to specify exact file here since we need to figure out whether a file is external or internal one
-					const moduleFileName = resolveModuleFileName(rootSourceFile.fileName, node.argument.literal.text, baseUrl);
-					return !getModuleInfo(moduleFileName, criteria).isExternal;
+					const resolvedModule = updateResultCommonParams.resolveReferencedModule(node);
+					if (resolvedModule === null) {
+						return false;
+					}
+
+					return !updateResultCommonParams.getModuleInfo(resolvedModule).isExternal;
 				},
 			},
 			{
@@ -396,7 +405,7 @@ interface UpdateParams {
 	getDeclarationsForExportedAssignment(exportAssignment: ts.ExportAssignment): ts.Declaration[];
 	getDeclarationUsagesSourceFiles(declaration: ts.NamedDeclaration): Set<ts.SourceFile | ts.ModuleDeclaration>;
 	areDeclarationSame(a: ts.NamedDeclaration, b: ts.NamedDeclaration): boolean;
-	resolveReferencedModule(node: ts.ExportDeclaration | ts.ModuleDeclaration): ts.SourceFile | ts.ModuleDeclaration | null;
+	resolveReferencedModule(node: ts.ExportDeclaration | ts.ModuleDeclaration | ts.ImportTypeNode): ts.SourceFile | ts.ModuleDeclaration | null;
 }
 
 const skippedNodes = [
@@ -585,21 +594,8 @@ function updateResultForModuleDeclaration(moduleDecl: ts.ModuleDeclaration, para
 	);
 }
 
-function resolveModuleFileName(currentFileName: string, moduleName: string, baseUrl?: string): string {
-	if (moduleName.startsWith('.')) {
-		return fixPath(path.join(currentFileName, '..', moduleName));
-	}
-
-	// determine if the module is a non-relative import that can be resolved with the baseUrl
-	if (baseUrl !== undefined) {
-		const filePath = `${path.join(baseUrl, moduleName)}.ts`;
-
-		if (fs.existsSync(filePath)) {
-			return fixPath(filePath);
-		}
-	}
-
-	return `node_modules/${moduleName}/`;
+function resolveModuleFileName(currentFileName: string, moduleName: string): string {
+	return moduleName.startsWith('.') ? fixPath(path.join(currentFileName, '..', moduleName)) : `node_modules/${moduleName}/`;
 }
 
 function addTypesReference(library: string, typesReferences: Set<string>): void {

--- a/src/generate-output.ts
+++ b/src/generate-output.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 
 import { packageVersion } from './helpers/package-version';
-import { modifiersToMap, recreateRootLevelNodeWithModifiers } from './helpers/typescript';
+import { getModifiers, modifiersToMap, recreateRootLevelNodeWithModifiers } from './helpers/typescript';
 
 export interface ModuleImportsSet {
 	defaultImports: Set<string>;
@@ -142,7 +142,7 @@ function getStatementText(statement: ts.Statement, includeSortingValue: boolean,
 					return node;
 				}
 
-				const modifiersMap = modifiersToMap(node.modifiers);
+				const modifiersMap = modifiersToMap(getModifiers(node));
 
 				if (
 					ts.isEnumDeclaration(node)

--- a/src/helpers/typescript.ts
+++ b/src/helpers/typescript.ts
@@ -278,24 +278,13 @@ function getExportsForName(
 
 export type ModifiersMap = Record<ts.ModifierSyntaxKind, boolean>;
 
-const modifiersPriority: Record<ts.ModifierSyntaxKind, number> = {
+const modifiersPriority: Partial<Record<ts.ModifierSyntaxKind, number>> = {
 	[ts.SyntaxKind.ExportKeyword]: 4,
 	[ts.SyntaxKind.DefaultKeyword]: 3,
 	[ts.SyntaxKind.DeclareKeyword]: 2,
 
 	[ts.SyntaxKind.AsyncKeyword]: 1,
 	[ts.SyntaxKind.ConstKeyword]: 1,
-
-	// we don't care about these modifiers as they are used in classes only and cannot be at the root level
-	[ts.SyntaxKind.AbstractKeyword]: 0,
-	[ts.SyntaxKind.ReadonlyKeyword]: 0,
-	[ts.SyntaxKind.StaticKeyword]: 0,
-	[ts.SyntaxKind.InKeyword]: 0,
-	[ts.SyntaxKind.OutKeyword]: 0,
-	[ts.SyntaxKind.OverrideKeyword]: 0,
-	[ts.SyntaxKind.PrivateKeyword]: 0,
-	[ts.SyntaxKind.ProtectedKeyword]: 0,
-	[ts.SyntaxKind.PublicKeyword]: 0,
 };
 
 export function modifiersToMap(modifiers: (readonly ts.Modifier[]) | undefined | null): ModifiersMap {

--- a/src/types-usage-evaluator.ts
+++ b/src/types-usage-evaluator.ts
@@ -2,7 +2,6 @@ import * as ts from 'typescript';
 import {
 	getActualSymbol,
 	isDeclareModule,
-	isNamedTupleMember,
 	isNodeNamedDeclaration,
 	splitTransientSymbol,
 } from './helpers/typescript';
@@ -85,8 +84,7 @@ export class TypesUsageEvaluator {
 			if (ts.isIdentifier(child)) {
 				// identifiers in labelled tuples don't have symbols for their labels
 				// so let's just skip them from collecting
-				// since this feature is for TypeScript > 4, we have to check that a function exist before accessing it
-				if (isNamedTupleMember(child.parent) && child.parent.name === child) {
+				if (ts.isNamedTupleMember(child.parent) && child.parent.name === child) {
 					continue;
 				}
 

--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/config.ts
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/config.ts
@@ -1,0 +1,5 @@
+import { TestCaseConfig } from '../../test-cases/test-case-config';
+
+const config: TestCaseConfig = {};
+
+export = config;

--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/input.ts
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/input.ts
@@ -1,0 +1,5 @@
+import { returnMyType } from "field/type";
+
+export function test() {
+	return returnMyType()
+}

--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/output.d.ts
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/output.d.ts
@@ -1,0 +1,6 @@
+export interface MyType {
+	field: string;
+}
+export declare function test(): MyType;
+
+export {};

--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/src/field/type.ts
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/src/field/type.ts
@@ -1,0 +1,9 @@
+export interface MyType {
+	field: string;
+}
+
+export function returnMyType(): MyType {
+	return {
+		field: "test"
+	}
+}

--- a/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/tsconfig.json
+++ b/tests/e2e/test-cases/import-from-non-relative-path-inferred-type/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": "./src"
+	}
+}

--- a/tests/e2e/test-cases/save-jsdoc/input.ts
+++ b/tests/e2e/test-cases/save-jsdoc/input.ts
@@ -13,7 +13,10 @@ export type ExportedType = string | number;
 /**
  * ExportedConstEnum JSDoc
  */
-export const enum ExportedConstEnum { Item }
+export const enum ExportedConstEnum {
+	/** Item description */
+	Item,
+}
 
 /**
  * ExportedEnum JSDoc

--- a/tests/e2e/test-cases/save-jsdoc/output.d.ts
+++ b/tests/e2e/test-cases/save-jsdoc/output.d.ts
@@ -9,6 +9,7 @@ export declare const enum NonExportedConstEnum {
 }
 declare class NonExportedClass {
 	method(): NonExportedEnum;
+	/** Method description */
 	method2(): NonExportedConstEnum;
 }
 /**
@@ -24,6 +25,7 @@ export declare type ExportedType = string | number;
  * ExportedConstEnum JSDoc
  */
 export declare const enum ExportedConstEnum {
+	/** Item description */
 	Item = 0
 }
 /**

--- a/tests/e2e/test-cases/save-jsdoc/some-class.ts
+++ b/tests/e2e/test-cases/save-jsdoc/some-class.ts
@@ -20,6 +20,7 @@ export class NonExportedClass {
 		return NonExportedEnum.First;
 	}
 
+	/** Method description */
 	public method2(): NonExportedConstEnum {
 		return NonExportedConstEnum.First;
 	}

--- a/tsconfig.options.json
+++ b/tsconfig.options.json
@@ -1,7 +1,8 @@
 {
 	"compilerOptions": {
 		"declaration": true,
-		"lib": ["es2015"],
+		"lib": ["es2020"],
+		"module": "commonjs",
 		"newLine": "LF",
 		"noEmitOnError": true,
 		"noFallthroughCasesInSwitch": true,
@@ -9,6 +10,6 @@
 		"noUnusedLocals": true,
 		"strict": true,
 		"stripInternal": true,
-		"target": "es5"
+		"target": "es2020"
 	}
 }


### PR DESCRIPTION
Originally created by @josh- in #219, but the changes needed some additional work so here it is.

I rebased Josh's changes on the latest repo state and added fixed on top of that.

This PR includes the following breaking changes:
- min typescript version changed from 3.0 to 4.5
- `yargs` was upgraded from 17.2 to 17.6
- min nodejs version changed from 12 to 14
- compilation target changed from es5 to es2020 (modules are still commonjs though)

Fixes #219