### PR TITLE
Fixed skipping checking `declare module` statements for recursive check

### DIFF
--- a/src/types-usage-evaluator.ts
+++ b/src/types-usage-evaluator.ts
@@ -62,10 +62,14 @@ export class TypesUsageEvaluator {
 			for (const statement of node.body.statements) {
 				this.computeUsageForNode(statement);
 			}
-		} else if (isNodeNamedDeclaration(node) && node.name) {
+		}
+
+		if (isNodeNamedDeclaration(node) && node.name) {
 			const childSymbol = this.getSymbol(node.name);
 			this.computeUsagesRecursively(node, childSymbol);
-		} else if (ts.isVariableStatement(node)) {
+		}
+
+		if (ts.isVariableStatement(node)) {
 			for (const varDeclaration of node.declarationList.declarations) {
 				this.computeUsageForNode(varDeclaration);
 			}

--- a/tests/e2e/test-cases/ambient-redeclare-types/config.ts
+++ b/tests/e2e/test-cases/ambient-redeclare-types/config.ts
@@ -1,0 +1,5 @@
+import { TestCaseConfig } from '../test-case-config';
+
+const config: TestCaseConfig = {};
+
+export = config;

--- a/tests/e2e/test-cases/ambient-redeclare-types/input.d.ts
+++ b/tests/e2e/test-cases/ambient-redeclare-types/input.d.ts
@@ -1,0 +1,13 @@
+// see https://github.com/dexie/Dexie.js/blob/f6a6f29183c7a05f732397524c48ce4c1236bd6e/src/public/index.d.ts#L34-L47
+
+import { ExportedType, Type1, Type2 } from './type';
+
+interface _Type1 extends Type1 {}
+interface _Type2 extends Type2 {}
+
+declare module ExportedType {
+  interface Type1 extends _Type1 {}
+  interface Type2 extends _Type2 {}
+}
+
+export { ExportedType };

--- a/tests/e2e/test-cases/ambient-redeclare-types/output.d.ts
+++ b/tests/e2e/test-cases/ambient-redeclare-types/output.d.ts
@@ -1,0 +1,24 @@
+export interface Type1 {
+}
+export interface Type2 {
+}
+export declare interface ExportedType {
+	Type1: {
+		prototype: Type1;
+	};
+	Type2: {
+		prototype: Type2;
+	};
+}
+export interface _Type1 extends Type1 {
+}
+export interface _Type2 extends Type2 {
+}
+export declare module ExportedType {
+	interface Type1 extends _Type1 {
+	}
+	interface Type2 extends _Type2 {
+	}
+}
+
+export {};

--- a/tests/e2e/test-cases/ambient-redeclare-types/type.d.ts
+++ b/tests/e2e/test-cases/ambient-redeclare-types/type.d.ts
@@ -1,0 +1,7 @@
+export interface Type1 {}
+export interface Type2 {}
+
+export declare interface ExportedType {
+	Type1: { prototype: Type1 };
+	Type2: { prototype: Type2 };
+}


### PR DESCRIPTION
As these nodes are modules and named nodes at the same time

Broken in 56b22bc6cd4ab54fca7f2d943121f7b8fb286d1b

Fixes #243