### PR TITLE
Fixed incorrect output if rename while re-exporting the default export without a name

### DIFF
--- a/tests/e2e/test-cases/export-default-unnamed-statement/another-class.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/another-class.ts
@@ -1,0 +1,3 @@
+export default class {
+	second: number = 1;
+}

--- a/tests/e2e/test-cases/export-default-unnamed-statement/another-func.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/another-func.ts
@@ -1,0 +1,1 @@
+export default function(second: number) {}

--- a/tests/e2e/test-cases/export-default-unnamed-statement/class.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/class.ts
@@ -1,0 +1,3 @@
+export default class {
+	first: number = 1;
+}

--- a/tests/e2e/test-cases/export-default-unnamed-statement/config.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/config.ts
@@ -1,0 +1,5 @@
+import { TestCaseConfig } from '../../test-cases/test-case-config';
+
+const config: TestCaseConfig = {};
+
+export = config;

--- a/tests/e2e/test-cases/export-default-unnamed-statement/func.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/func.ts
@@ -1,0 +1,1 @@
+export default function(first: number) {}

--- a/tests/e2e/test-cases/export-default-unnamed-statement/input.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/input.ts
@@ -1,0 +1,9 @@
+export { default as myFunc1 } from './func';
+export { default as myFunc2 } from './func';
+export { default as myFunc3 } from './another-func';
+export { default as myFunc4 } from './another-func';
+
+export { default as myClass1 } from './class';
+export { default as myClass2 } from './class';
+export { default as myClass3 } from './another-class';
+export { default as myClass4 } from './another-class';

--- a/tests/e2e/test-cases/export-default-unnamed-statement/output.d.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/output.d.ts
@@ -1,0 +1,21 @@
+declare function __DTS_BUNDLE_GENERATOR__GENERATED_NAME$1(first: number): void;
+declare function __DTS_BUNDLE_GENERATOR__GENERATED_NAME$2(second: number): void;
+declare class __DTS_BUNDLE_GENERATOR__GENERATED_NAME$3 {
+	first: number;
+}
+declare class __DTS_BUNDLE_GENERATOR__GENERATED_NAME$4 {
+	second: number;
+}
+
+export {
+	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$1 as myFunc1,
+	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$1 as myFunc2,
+	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$2 as myFunc3,
+	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$2 as myFunc4,
+	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$3 as myClass1,
+	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$3 as myClass2,
+	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$4 as myClass3,
+	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$4 as myClass4,
+};
+
+export {};


### PR DESCRIPTION
Fixes #185

For any unnamed statement the tool will generate a name `__DTS_BUNDLE_GENERATOR__GENERATED_NAME${number within a compilation}` (e.g. `__DTS_BUNDLE_GENERATOR__GENERATED_NAME$3`) and then use that name to re-export with exported name via `export { name as name }` syntax, e.g. `export { __DTS_BUNDLE_GENERATOR__GENERATED_NAME$3 as myName }`.

See test cases for more examples.