### PR TITLE
Resolve export default expression name collision

### DIFF
--- a/tests/e2e/test-cases/export-default-unnamed-statement/input.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/input.ts
@@ -7,3 +7,7 @@ export { default as myClass1 } from './class';
 export { default as myClass2 } from './class';
 export { default as myClass3 } from './another-class';
 export { default as myClass4 } from './another-class';
+
+export { default as number } from './number';
+export { default as string } from './string';
+export { default as object } from './object';

--- a/tests/e2e/test-cases/export-default-unnamed-statement/number.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/number.ts
@@ -1,0 +1,1 @@
+export default 0;

--- a/tests/e2e/test-cases/export-default-unnamed-statement/object.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/object.ts
@@ -1,0 +1,3 @@
+export default {
+  type: 'object',
+};

--- a/tests/e2e/test-cases/export-default-unnamed-statement/output.d.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/output.d.ts
@@ -6,6 +6,11 @@ declare class __DTS_BUNDLE_GENERATOR__GENERATED_NAME$3 {
 declare class __DTS_BUNDLE_GENERATOR__GENERATED_NAME$4 {
 	second: number;
 }
+declare const _default: 0;
+declare const _default: "";
+declare const _default: {
+	type: string;
+};
 
 export {
 	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$1 as myFunc1,
@@ -16,6 +21,9 @@ export {
 	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$3 as myClass2,
 	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$4 as myClass3,
 	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$4 as myClass4,
+	_default as number,
+	_default as object,
+	_default as string,
 };
 
 export {};

--- a/tests/e2e/test-cases/export-default-unnamed-statement/output.d.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/output.d.ts
@@ -7,8 +7,8 @@ declare class __DTS_BUNDLE_GENERATOR__GENERATED_NAME$4 {
 	second: number;
 }
 declare const _default: 0;
-declare const _default: "";
-declare const _default: {
+declare const _default$2: "";
+declare const _default$3: {
 	type: string;
 };
 
@@ -22,8 +22,8 @@ export {
 	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$4 as myClass3,
 	__DTS_BUNDLE_GENERATOR__GENERATED_NAME$4 as myClass4,
 	_default as number,
-	_default as object,
-	_default as string,
+	_default$2 as string,
+	_default$3 as object,
 };
 
 export {};

--- a/tests/e2e/test-cases/export-default-unnamed-statement/string.ts
+++ b/tests/e2e/test-cases/export-default-unnamed-statement/string.ts
@@ -1,0 +1,1 @@
+export default '';


### PR DESCRIPTION
~Fixes #116~

## Issue
exporting default unnamed expression bundles the same name

```ts
// file ./number.ts
export default 0;

// file ./object.ts
export default {
  type: 'object',
};

// file ./string.ts
export default '';

// file ./input.ts
export { default as number } from './number';
export { default as object } from './object';
export { default as string } from './string';
```
result:
```ts
declare const _default: 0;
declare const _default: "";
declare const _default: {
	type: string;
};

export {
  _default as number,
  _default as object,
  _default as string,
};
```

See https://github.com/timocov/dts-bundle-generator/commit/3be37c918029262e0a9448afd2e485c5907b11b3 for reference

## Suggestion
Using a `nameCollision` map to detect and rename variable collisions.

```ts
declare const _default: 0;
declare const _default$2: "";
declare const _default$3: {
	type: string;
};

export {
  _default as number,
  _default$2 as string,
  _default$3 as object,
};
```

See https://github.com/timocov/dts-bundle-generator/commit/6c033c04af7de9a2ca0f9a41deab3dc54e5003cf for reference


## Restrictions
There are the same restrictions as with the current unnamed class or function statements behaviour `export default class {}`.
It can not be used as reference for other declarations:
```ts
import something from './file-with-export-default`;

export type T = typeof something; // do not work (even with the unnamed class or function)
```

## Similar issues
It looks like it also fixes this https://github.com/timocov/dts-bundle-generator/issues/116