### PR TITLE
support var symbol renaming

### DIFF
--- a/src/collisions-resolver.ts
+++ b/src/collisions-resolver.ts
@@ -11,8 +11,7 @@ import { verboseLog } from './logger';
 
 const renamingSupportedSymbols: readonly ts.SymbolFlags[] = [
 	ts.SymbolFlags.Alias,
-	ts.SymbolFlags.FunctionScopedVariable,
-	ts.SymbolFlags.BlockScopedVariable,
+	ts.SymbolFlags.Variable,
 	ts.SymbolFlags.Class,
 	ts.SymbolFlags.Enum,
 	ts.SymbolFlags.Function,

--- a/src/collisions-resolver.ts
+++ b/src/collisions-resolver.ts
@@ -11,6 +11,7 @@ import { verboseLog } from './logger';
 
 const renamingSupportedSymbols: readonly ts.SymbolFlags[] = [
 	ts.SymbolFlags.Alias,
+	ts.SymbolFlags.FunctionScopedVariable,
 	ts.SymbolFlags.BlockScopedVariable,
 	ts.SymbolFlags.Class,
 	ts.SymbolFlags.Enum,

--- a/tests/e2e/test-cases/names-collision-across-files/file1.ts
+++ b/tests/e2e/test-cases/names-collision-across-files/file1.ts
@@ -2,6 +2,9 @@ const TEMPLATE = 'template1';
 export default TEMPLATE;
 
 export const MergedSymbol = '';
+
+export var Variable = 1;
+
 export interface MergedSymbol {
 	test(): void
 };

--- a/tests/e2e/test-cases/names-collision-across-files/file2.ts
+++ b/tests/e2e/test-cases/names-collision-across-files/file2.ts
@@ -2,6 +2,9 @@ const TEMPLATE = 'template2';
 export default TEMPLATE;
 
 export const MergedSymbol = '';
+
+export var Variable = '';
+
 export interface MergedSymbol {
 	test(): void
 };

--- a/tests/e2e/test-cases/names-collision-across-files/input.ts
+++ b/tests/e2e/test-cases/names-collision-across-files/input.ts
@@ -10,6 +10,7 @@ export {
 	TypeName as T1,
 	func as f1,
 	NamespaceName as NS1,
+	Variable as V1,
 
 	// rename these to include them into import
 	AnotherInterface as AI1,
@@ -24,6 +25,7 @@ export {
 	TypeName as T2,
 	func as f2,
 	NamespaceName as NS2,
+	Variable as V2,
 
 	// yes, keep these without renaming so we can check that these aren't exported with wrong names
 	AnotherInterface,

--- a/tests/e2e/test-cases/names-collision-across-files/output.d.ts
+++ b/tests/e2e/test-cases/names-collision-across-files/output.d.ts
@@ -25,6 +25,7 @@ declare namespace ExportEqNs$1 {
 }
 declare const TEMPLATE = "template1";
 declare const MergedSymbol = "";
+declare var Variable: number;
 interface MergedSymbol {
 	test(): void;
 }
@@ -43,6 +44,7 @@ declare namespace NamespaceName {
 }
 declare const TEMPLATE$1 = "template2";
 declare const MergedSymbol$1 = "";
+declare var Variable$1: string;
 interface MergedSymbol$1 {
 	test(): void;
 }
@@ -93,6 +95,8 @@ export {
 	TEMPLATE$1 as TEMPLATE2,
 	TypeName as T1,
 	TypeName$1 as T2,
+	Variable as V1,
+	Variable$1 as V2,
 	anotherFunc as af1,
 	anotherFunc$1 as anotherFunc,
 	func as f1,


### PR DESCRIPTION
Not sure if this symbol is missing in`renamingSupportedSymbols` on purpose. 

Currently bundling the `var` declarations throws an error `Something went wrong - a symbol Variable for top-level identifier Variable cannot be renamed`