### PR TITLE
Performance improvements

### DIFF
--- a/src/bin/dts-bundle-generator.ts
+++ b/src/bin/dts-bundle-generator.ts
@@ -261,6 +261,9 @@ function main(): void {
 		warnLog('Compiler option "skipLibCheck" is disabled to properly check generated output');
 	}
 
+	// we want to turn this option on because in this case the compile will generate declaration diagnostics out of the box
+	compilerOptions.declaration = true;
+
 	let checkFailed = false;
 	for (const outputFile of outFilesToCheck) {
 		const program = ts.createProgram([outputFile], compilerOptions);

--- a/src/bundle-generator.ts
+++ b/src/bundle-generator.ts
@@ -151,8 +151,6 @@ export function generateDtsBundle(entries: readonly EntryPointConfig[], options:
 		return !program.isSourceFileDefaultLibrary(file);
 	});
 
-	verboseLog(`Input source files:\n  ${sourceFiles.map((file: ts.SourceFile) => file.fileName).join('\n  ')}`);
-
 	const typesUsageEvaluator = new TypesUsageEvaluator(sourceFiles, typeChecker);
 
 	return entries.map((entryConfig: EntryPointConfig) => {
@@ -1118,7 +1116,7 @@ export function generateDtsBundle(entries: readonly EntryPointConfig[], options:
 		}
 
 		for (const sourceFile of sourceFiles) {
-			verboseLog(`\n\n======= Preparing file: ${sourceFile.fileName} =======`);
+			verboseLog(`======= Processing ${sourceFile.fileName} =======`);
 
 			const updateFn = sourceFile === rootSourceFile ? updateResultForRootModule : updateResultForAnyModule;
 			const currentModule = getFileModuleInfo(sourceFile.fileName, criteria);

--- a/src/compile-dts.ts
+++ b/src/compile-dts.ts
@@ -41,6 +41,9 @@ export function compileDts(rootFiles: readonly string[], preferredConfigPath?: s
 	compilerOptions.tsBuildInfoFile = undefined;
 	compilerOptions.declarationDir = undefined;
 
+	// we want to turn this option on because in this case the compile will generate declaration diagnostics out of the box
+	compilerOptions.declaration = true;
+
 	if (compilerOptions.composite) {
 		warnLog(`Composite projects aren't supported at the time. Prefer to use non-composite project to generate declarations instead or just ignore this message if everything works fine. See https://github.com/timocov/dts-bundle-generator/issues/93`);
 		compilerOptions.composite = undefined;

--- a/src/helpers/check-diagnostics-errors.ts
+++ b/src/helpers/check-diagnostics-errors.ts
@@ -8,8 +8,11 @@ const formatDiagnosticsHost: ts.FormatDiagnosticsHost = {
 };
 
 export function checkProgramDiagnosticsErrors(program: ts.Program): void {
+	if (!program.getCompilerOptions().declaration) {
+		throw new Error(`Something went wrong - the program doesn't have declaration option enabled`);
+	}
+
 	checkDiagnosticsErrors(ts.getPreEmitDiagnostics(program), 'Compiled with errors');
-	checkDiagnosticsErrors(program.getDeclarationDiagnostics(), 'Compiled with errors');
 }
 
 export function checkDiagnosticsErrors(diagnostics: readonly ts.Diagnostic[], failMessage: string): void {


### PR DESCRIPTION
Fixes #302

With the following input _declaration_ file:

```ts
// index.d.ts
import { Context } from 'effect';

export declare const foobar: <Self, Shape>() => Context.TagClass<Self, string, Shape>;
export type A = string;

export {};
```

The execution time of `./node_modules/.bin/dts-bundle-generator src/index.d.ts --no-check` dropped from 2.64s to 1.26s (more than 2x), which is much closed to just running `tsc` 0.96s (but still not ideal).

| cmd | NPM | PR | Diff |
|---|---|---|---|
| `dts-bundle-generator src/index.d.ts --no-check` [^1] | 2.64s | 1.26s | -1.38s (-52%) |
| `dts-bundle-generator src/index.d.ts` [^2] | 3.45s | 2.07s | -1.38s (-40%) |
| `dts-bundle-generator src/index.ts --no-check` | 3.3s | 1.8s | -1.5s (-45%) |
| `dts-bundle-generator src/index.ts` [^2] | 4s | 2.52s | -1.48s (-37%) |

[^1]: If all input files are declaration files then it goes much faster because there is no need in extra
[^2]: `--no-check` disables extra compilation after the job is done thus is faster, but less safer

So overall it is around 40-50% execution time decrease on this particular example. It is worth to say that `effect` is a massive library and it pushes the compiler a lot in terms of types, parsing/processing/validation time.