### PR TITLE
fix: dont strip `type` keyword from types imported from node modules

### DIFF
--- a/src/generate-output.ts
+++ b/src/generate-output.ts
@@ -329,8 +329,14 @@ function generateImports(libraryName: string, imports: ModuleImportsSet): string
 	Array.from(imports.requireImports).sort().forEach((importName: string) => result.push(`import ${importName} = require('${libraryName}');`));
 	Array.from(imports.defaultImports).sort().forEach((importName: string) => result.push(`import ${importName} ${fromEnding}`));
 
+	// For each type-only import, check if it exists in the `namedImports` map and remove it
+	// otherwise we might end up with a type import and a regular import in the bundle.
+	for (const key of imports.typeImports.keys()) {
+		imports.namedImports.delete(key);
+	}
+
 	if (imports.typeImports.size !== 0) {
-		result.push(`import { ${
+		result.push(`import { type ${
 			Array.from(imports.typeImports.entries())
 				.map(([localName, importedName]: [string, string]) => renamedImportValue(importedName, localName))
 				.sort()

--- a/src/generate-output.ts
+++ b/src/generate-output.ts
@@ -7,6 +7,7 @@ export interface ModuleImportsSet {
 	defaultImports: Set<string>;
 	nsImport: string | null;
 	namedImports: Map<string, string>;
+	typeImports: Map<string, string>;
 	requireImports: Set<string>;
 	reExports: Map<string, string>;
 }
@@ -327,6 +328,15 @@ function generateImports(libraryName: string, imports: ModuleImportsSet): string
 
 	Array.from(imports.requireImports).sort().forEach((importName: string) => result.push(`import ${importName} = require('${libraryName}');`));
 	Array.from(imports.defaultImports).sort().forEach((importName: string) => result.push(`import ${importName} ${fromEnding}`));
+
+	if (imports.typeImports.size !== 0) {
+		result.push(`import { ${
+			Array.from(imports.typeImports.entries())
+				.map(([localName, importedName]: [string, string]) => renamedImportValue(importedName, localName))
+				.sort()
+				.join(', type ')
+		} } ${fromEnding}`);
+	}
 
 	if (imports.namedImports.size !== 0) {
 		result.push(`import { ${

--- a/tests/e2e/test-cases/import-type-from-deps/output.d.ts
+++ b/tests/e2e/test-cases/import-type-from-deps/output.d.ts
@@ -1,4 +1,4 @@
-import { InterfaceWithFields } from 'fake-package';
+import { type InterfaceWithFields } from 'fake-package';
 
 export declare type FakePackageType = InterfaceWithFields | string;
 export type TestType = InterfaceWithFields | FakePackageType;

--- a/tests/e2e/test-cases/preserve-type-imports/config.ts
+++ b/tests/e2e/test-cases/preserve-type-imports/config.ts
@@ -1,0 +1,5 @@
+import type { TestCaseConfig } from '../test-case-config';
+
+const config: TestCaseConfig = {};
+
+export = config;

--- a/tests/e2e/test-cases/preserve-type-imports/index.spec.js
+++ b/tests/e2e/test-cases/preserve-type-imports/index.spec.js
@@ -1,0 +1,1 @@
+require('../run-test-case').runTestCase(__dirname);

--- a/tests/e2e/test-cases/preserve-type-imports/input.ts
+++ b/tests/e2e/test-cases/preserve-type-imports/input.ts
@@ -1,0 +1,6 @@
+import type { Diagnostic, AffectedFileResult as RenamedImport } from "typescript";
+
+export type MyType = {
+  value: Diagnostic;
+  alias: RenamedImport<number>
+};

--- a/tests/e2e/test-cases/preserve-type-imports/output.d.ts
+++ b/tests/e2e/test-cases/preserve-type-imports/output.d.ts
@@ -1,0 +1,8 @@
+import { type Diagnostic, type AffectedFileResult as RenamedImport } from 'typescript';
+
+export type MyType = {
+	value: Diagnostic;
+	alias: RenamedImport<number>;
+};
+
+export {};

--- a/tests/e2e/test-cases/preserve-type-imports/output.d.ts
+++ b/tests/e2e/test-cases/preserve-type-imports/output.d.ts
@@ -1,4 +1,4 @@
-import { type Diagnostic, type AffectedFileResult as RenamedImport } from 'typescript';
+import { type AffectedFileResult as RenamedImport, type Diagnostic } from 'typescript';
 
 export type MyType = {
 	value: Diagnostic;

--- a/tests/e2e/test-cases/preserve-type-imports/tsconfig.json
+++ b/tests/e2e/test-cases/preserve-type-imports/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"verbatimModuleSyntax": true
+	}
+}


### PR DESCRIPTION
Fixes #320 