### PR TITLE
Don't error on missing re-exported declarations

### DIFF
--- a/src/types-usage-evaluator.ts
+++ b/src/types-usage-evaluator.ts
@@ -158,7 +158,7 @@ export class TypesUsageEvaluator {
 					this.addUsages(exportElementSymbol, exportElementOwnSymbol);
 					this.addUsages(this.getActualSymbol(exportElementSymbol), exportElementOwnSymbol);
 				} catch (error) {
-					warnLog(`Unhandled declaration detected. Make sure types are installed for: ${node.moduleSpecifier?.getText()}!`);
+					warnLog(`Could not resolve declaration. Are types installed for module: ${node.moduleSpecifier?.getText()}?`);
 				}
 			}
 		}

--- a/src/types-usage-evaluator.ts
+++ b/src/types-usage-evaluator.ts
@@ -11,6 +11,7 @@ import {
 	isNodeNamedDeclaration,
 	splitTransientSymbol,
 } from './helpers/typescript';
+import { warnLog } from './logger';
 
 export class TypesUsageEvaluator {
 	private readonly typeChecker: ts.TypeChecker;
@@ -141,20 +142,24 @@ export class TypesUsageEvaluator {
 		// `export {}` or `export {} from 'mod'`
 		if (ts.isExportDeclaration(node) && node.exportClause !== undefined && ts.isNamedExports(node.exportClause)) {
 			for (const exportElement of node.exportClause.elements) {
-				const exportElementSymbol = getImportExportReferencedSymbol(exportElement, this.typeChecker);
+				try {
+					const exportElementSymbol = getImportExportReferencedSymbol(exportElement, this.typeChecker);
 
-				// i.e. `import * as NS from './local-module'`
-				const namespaceImportForElement = getDeclarationsForSymbol(exportElementSymbol).find(ts.isNamespaceImport);
-				if (namespaceImportForElement !== undefined) {
-					// the namespaced import itself doesn't add a "usage", but re-export of that imported namespace does
-					// so here we're handling the case where previously imported namespace import has been re-exported from a module
-					this.addUsagesForNamespacedModule(namespaceImportForElement, namespaceImportForElement.parent.parent.moduleSpecifier as ts.StringLiteral);
+					// i.e. `import * as NS from './local-module'`
+					const namespaceImportForElement = getDeclarationsForSymbol(exportElementSymbol).find(ts.isNamespaceImport);
+					if (namespaceImportForElement !== undefined) {
+						// the namespaced import itself doesn't add a "usage", but re-export of that imported namespace does
+						// so here we're handling the case where previously imported namespace import has been re-exported from a module
+						this.addUsagesForNamespacedModule(namespaceImportForElement, namespaceImportForElement.parent.parent.moduleSpecifier as ts.StringLiteral);
+					}
+
+					// "link" referenced symbol with its import
+					const exportElementOwnSymbol = this.getNodeOwnSymbol(exportElement.name);
+					this.addUsages(exportElementSymbol, exportElementOwnSymbol);
+					this.addUsages(this.getActualSymbol(exportElementSymbol), exportElementOwnSymbol);
+				} catch (error) {
+					warnLog(`Unhandled declaration detected. Make sure types are installed for: ${node.moduleSpecifier?.getText()}!`);
 				}
-
-				// "link" referenced symbol with its import
-				const exportElementOwnSymbol = this.getNodeOwnSymbol(exportElement.name);
-				this.addUsages(exportElementSymbol, exportElementOwnSymbol);
-				this.addUsages(this.getActualSymbol(exportElementSymbol), exportElementOwnSymbol);
 			}
 		}
 


### PR DESCRIPTION
Hey 👋 

Many thanks for creating this package. It's really useful! 👏👏👏

I've come across a situation where some packages re-export types but due to having the re-exported types dependency set as a dev dependency it isn't installed via npm and `dts-bundle-generator` errors out.

```
// node_modules/my-package/dist/index.d.ts
export { TypeA, TypeB } from '@types/some-package'
```

```
Error while bundling types: TypeError: Cannot read properties of undefined (reading 'declarations')
    at getDeclarationsForSymbol (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/dts-bundle-generator/dist/helpers/typescript.js:114:16)
    at TypesUsageEvaluator.computeUsageForNode (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/dts-bundle-generator/dist/types-usage-evaluator.js:117:97)
    at visitNodes (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/typescript/lib/typescript.js:31751:22)
    at forEachChildInSourceFile (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/typescript/lib/typescript.js:31964:12)
    at Object.forEachChild (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/typescript/lib/typescript.js:32264:35)
    at TypesUsageEvaluator.computeUsages (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/dts-bundle-generator/dist/types-usage-evaluator.js:59:16)
    at new TypesUsageEvaluator (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/dts-bundle-generator/dist/types-usage-evaluator.js:12:14)
    at generateDtsBundle (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/dts-bundle-generator/dist/bundle-generator.js:20:33)
    at generateTypes (file:///Users/jackwestbrook/dev/grafana/plugin-tools/packages/plugin-types-bundler/dist/bundleTypes.js:22:17)
    at file:///Users/jackwestbrook/dev/grafana/plugin-tools/packages/plugin-types-bundler/dist/bin/run.js:18:5
```

This error was quite confusing for me and solving it consisted of installing the missing package in my project. However I think it might make sense to offer the option to warn users that it's missing and allow execution to continue. Alternatively maybe it's enough to throw a more helpful error msg and force the user to install the missing package to make sure types are correctly bundled. I'm opening this PR as a starting point to discuss this further.
 
From my investigations without the re-exported package installed it seems typescript treats the missing re-exported packages as `any` and doesn't seem to surface any errors (at least none that I could find).

Additionally whilst doing this I noticed there is no way to change the log level when using this packages API. Is that something you'd consider adding as an option?
